### PR TITLE
[Frontend] Clarify model_type error messages

### DIFF
--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -166,15 +166,15 @@ class BaseMultiModalItemTracker(ABC, Generic[_T]):
             if model_type == "molmo":
                 return ""
 
-            raise TypeError(f"Unknown model type: {model_type}")
+            raise TypeError(f"Unknown {modality} model type: {model_type}")
         elif modality == "audio":
             if model_type == "ultravox":
                 return "<|reserved_special_token_0|>"
-            raise TypeError(f"Unknown model type: {model_type}")
+            raise TypeError(f"Unknown {modality} model type: {model_type}")
         elif modality == "video":
             if model_type == "qwen2_vl":
                 return "<|vision_start|><|video_pad|><|vision_end|>"
-            raise TypeError(f"Unknown model type: {model_type}")
+            raise TypeError(f"Unknown {modality} model type: {model_type}")
         else:
             raise TypeError(f"Unknown modality: {modality}")
 


### PR DESCRIPTION
When there is a multi-modal model mismatch in chat mode, it is unclear what kind of match it was trying to make. This adds the modality to the error message to make it clear what kind of match it was making.